### PR TITLE
More predictable url for tar.gz

### DIFF
--- a/org.plomgrading.PlomClient.yaml
+++ b/org.plomgrading.PlomClient.yaml
@@ -33,7 +33,7 @@ modules:
       - install -D PlomClient.workaround $FLATPAK_DEST/bin/PlomClient
     sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/7d/9a/755888758c21c322887b70cab351cc6d288947126fb89d71e9e9272066ca/plom-0.7.0.tar.gz
+        url: https://pypi.io/packages/source/p/plom/plom-0.7.0.tar.gz
         sha256: 656c4e55981b10cf2cbbfa3ac76ae558e862b3fdbf0396d57d96a04950ae4669
       - type: file
         path: PlomClient.workaround


### PR DESCRIPTION
This should make maintainence a little easier.  Hat tip [1].

[1] https://stackoverflow.com/questions/47781035/does-pypi-have-simple-urls-for-package-downloads