### PR TITLE
Manager tool needs filesystem access to write files

### DIFF
--- a/org.plomgrading.PlomClient.yaml
+++ b/org.plomgrading.PlomClient.yaml
@@ -6,7 +6,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# TODO: drop toml and packaging if they come from the PyQy.BaseApp
+# TODO: drop filesystem permissions if manager split off to new flatpak
 
 app-id: org.plomgrading.PlomClient
 runtime: org.kde.Platform
@@ -19,6 +19,7 @@ finish-args:
   - --share=ipc
   - --device=dri
   - --share=network
+  - --filesystem=home
 base: com.riverbankcomputing.PyQt.BaseApp
 base-version: 5.15-21.08
 cleanup-commands:


### PR DESCRIPTION
We may split client and manager into two different flatpaks which would
allow client to have fewer permissions and fewer deps.