### PR TITLE
Use fallback x11 now that we're on pyqt6

### DIFF
--- a/org.plomgrading.PlomClient.yaml
+++ b/org.plomgrading.PlomClient.yaml
@@ -16,7 +16,7 @@ sdk: org.kde.Sdk
 command: PlomClient
 finish-args:
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --share=ipc
   - --device=dri
   - --share=network


### PR DESCRIPTION
Fixes Issue #16 (and hopefully #32 as well)